### PR TITLE
fix style.css interferes with other styles #16

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -27,7 +27,12 @@
 |*|  SOFTWARE.
 \*/
 
-.btn-group-xs > .btn, .btn-xs {
+/* include the .switch.btn itself */
+.btn-group-xs > .switch.btn,
+.switch.btn-xs,
+/* include .btn elements inside the .switch */
+.btn-group-xs > .switch .btn,
+.switch .btn-xs {
 	padding: .35rem .4rem .25rem .4rem;
 	font-size: .875rem;
 	line-height: .5;


### PR DESCRIPTION
This is an attempt to limit the `.btn-group-xs` and `.btn-xs` css classes to apply only to the `switch` component to prevent them from interfering with bootstrap-styled components.